### PR TITLE
WPS tests for Terrarium, and analytics URLs.

### DIFF
--- a/wwwroot/init/test.json
+++ b/wwwroot/init/test.json
@@ -330,7 +330,7 @@
             {
               "name": "GeoJsonTest",
               "type": "wps",
-              "url": "http://sparrow.terria.io:5001?service=wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
               "identifier": "geojson_test",
               "opacity" : 0.6,
               "ignoreUnknownTileErrors": true

--- a/wwwroot/init/test.json
+++ b/wwwroot/init/test.json
@@ -277,6 +277,89 @@
           ]
         },
         {
+          "name": "WPS",
+          "type": "group",
+          "preserveOrder": true,
+          "items": [
+            {
+              "name": "InputsTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "inputs_test"
+            },
+            {
+              "name": "PointTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "point_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "LineTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "line_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "RectangleTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "bbox_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "PolygonTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "polygon_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "RegionTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "region_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "GeoJsonTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001?service=wps",
+              "identifier": "geojson_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "ContextTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "point_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true,
+              "contextItem": {
+                  "name": "Analysis Study Area",
+                  "description": "Show where it is possible to use the analytical functions of this test function.",
+                  "layers": "awavea-interim:outline_ww3.aus_4m",
+                  "url": "http://oa-gis.csiro.au/geoserver/ows",
+                  "type": "wms",
+                  "legendUrl": "",
+                  "rectangle": [
+                    109.0,
+                    -48.0,
+                    158.0,
+                    -5.0
+                  ]
+                }
+            }
+          ]
+        },
+        {
           "name": "GeoJSON files",
           "type": "group",
           "items": [
@@ -430,7 +513,7 @@
                     }
                   }
                 ]
-              }              
+              }
             }
           ]
         },
@@ -471,17 +554,17 @@
         {
           "name": "Regions like this",
           "type": "places-like-me-function",
-          "url": "http://parlmap.terria.io:31113/jobs"
+          "url": "http://analytics.terria.io:31113/jobs"
         },
         {
           "name": "What makes this region unique or special?",
           "type": "why-am-i-special-function",
-          "url": "http://parlmap.terria.io:31113/jobs"
+          "url": "http://analytics.terria.io:31113/jobs"
         },
         {
           "name": "Spatial Detailing",
           "type": "spatial-detailing-function",
-          "url": "http://parlmap.terria.io:31113/jobs"
+          "url": "http://analytics.terria.io:31113/jobs"
         },
         {
           "name": "Sample Data",


### PR DESCRIPTION
Adds WPS tests that are already in NM to Terrarium, also fixes analytics URLs (I'm puzzled why these weren't correct already, but anyway). 
